### PR TITLE
[1LP][RFR]: Fix navigations and introduce all method for projects

### DIFF
--- a/rhamt/entities/__init__.py
+++ b/rhamt/entities/__init__.py
@@ -2,6 +2,7 @@ import attr
 from wait_for import wait_for
 from widgetastic.widget import Text
 from widgetastic.widget import View
+from widgetastic_patternfly import Button
 
 from rhamt.base.application.implementations.web_ui import RhamtNavigateStep
 from rhamt.base.application.implementations.web_ui import ViaWebUI
@@ -11,7 +12,28 @@ from rhamt.widgetastic import HOMENavigation
 from rhamt.widgetastic import RHAMTNavigation
 
 
+class BlankStateView(View):
+    """This view represent web-console without any project i.e. blank state"""
+
+    ROOT = ".//div[contains(@class, 'blank-slate')]"
+
+    title = Text(locator=".//h1")
+    welcome_help = Text(locator=".//div[@class='welcome-help-text']")
+    new_project_button = Button("New Project")
+    documentation = Text(locator=".//a[contains(text(), 'documentation')]")
+
+    @property
+    def is_displayed(self):
+        return (
+            self.title.is_displayed
+            and self.title.text == "Welcome to the Web Console."
+            and self.new_project_button.is_displayed
+        )
+
+
 class BaseLoggedInPage(View):
+    """This is base view for RHAMT"""
+
     header = Text(locator=".//span[@id='header-logo']")
     home_navigation = HOMENavigation("//ul")
     navigation = RHAMTNavigation('//ul[@class="list-group"]')
@@ -22,6 +44,9 @@ class BaseLoggedInPage(View):
     help = DropdownMenu(
         locator=".//li[contains(@class, 'dropdown') and .//span[@class='pficon pficon-help']]"
     )
+
+    # only if no project available
+    blank_state = View.nested(BlankStateView)
 
     @property
     def is_displayed(self):

--- a/rhamt/entities/__init__.py
+++ b/rhamt/entities/__init__.py
@@ -45,8 +45,13 @@ class BaseLoggedInPage(View):
         locator=".//li[contains(@class, 'dropdown') and .//span[@class='pficon pficon-help']]"
     )
 
-    # only if no project available
+    # only if no projectavailable
     blank_state = View.nested(BlankStateView)
+
+    @property
+    def is_empty(self):
+        """Check project is available or not; blank state"""
+        return self.blank_state.is_displayed
 
     @property
     def is_displayed(self):
@@ -69,3 +74,7 @@ class LoggedIn(RhamtNavigateStep):
     def step(self):
         self.application.web_ui.widgetastic_browser.url = self.application.hostname
         wait_for(lambda: self.view.is_displayed, timeout="30s")
+
+    def resetter(self, *args, **kwargs):
+        # If some views stuck while navigation; reset navigation by clicking logo
+        self.view.header.click()

--- a/rhamt/entities/projects.py
+++ b/rhamt/entities/projects.py
@@ -25,15 +25,39 @@ from rhamt.widgetastic import TransformationPath
 
 
 class AllProjectView(BaseLoggedInPage):
-    project_list = ProjectList("projects-list")
+    """This view represent Project All View"""
+
+    ROOT = ".//div[contains(@class, 'projects-list-page')]"
+
+    title = Text(".//div[contains(@class, 'projects-bar')]/h1")
+    search = Input(".//input[contains(@name, 'searchValue')]")
+    # TODO: add custom sort widget
+
+    projects = ProjectList("projects-list")
     new_project_button = Button("New Project")
-    project = Text(
-        locator=".//div[contains(@class, 'projects-bar')]/h1[normalize-space(.)='Projects']"
-    )
+
+    @View.nested
+    class no_matches(View):  # noqa
+        """After search if no match found"""
+
+        text = Text(".//div[contains(@class, 'no-matches')]")
+        remove = Text(".//div[contains(@class, 'no-matches')]/a")
+
+    def clear_search(self):
+        """Clear search"""
+        if self.search.value:
+            self.search.fill("")
+
+    @property
+    def is_empty(self):
+        """Check project is available or not; blank state"""
+        return self.blank_state.is_displayed
 
     @property
     def is_displayed(self):
-        return self.new_project_button.is_displayed and self.project.is_displayed
+        return self.is_empty or (
+            self.new_project_button.is_displayed and self.title.text == "Projects"
+        )
 
 
 class AddProjectView(AllProjectView):
@@ -66,7 +90,7 @@ class AddProjectView(AllProjectView):
 
         @property
         def is_displayed(self):
-            return self.upload_file.is_displayed and self.add_applications.is_displayed
+            return self.add_applications.is_displayed
 
         def fill(self, values):
             app_list = values.get("app_list")
@@ -114,6 +138,14 @@ class AddProjectView(AllProjectView):
         def after_fill(self, was_change):
             self.save_and_run.click()
 
+    @property
+    def is_displayed(self):
+        return (
+            self.create_project.is_displayed
+            or self.add_applications.is_displayed
+            or self.configure_analysis.is_displayed
+        )
+
 
 class DetailsProjectView(AllProjectView):
     run_analysis_button = Button("Run Analysis")
@@ -154,13 +186,15 @@ class DeleteProjectView(AllProjectView):
 class Project(BaseEntity, Updateable):
 
     name = attr.ib()
-    description = attr.ib()
+    description = attr.ib(default=None)
     app_list = attr.ib(default=None)
     transformation_path = attr.ib(default=None)
 
-    def exists(self, project_name):
+    @property
+    def exists(self):
+        """Check project exist or not"""
         view = navigate_to(self.parent, "All")
-        return view.project_list.exists(project_name)
+        return self.name in view.projects.items
 
     def update(self, updates):
         view = navigate_to(self, "Edit")
@@ -173,9 +207,9 @@ class Project(BaseEntity, Updateable):
         view.wait_displayed()
         assert view.is_displayed
 
-    def delete(self, project_name):
+    def delete(self):
         view = navigate_to(self, "Delete")
-        view.fill({"delete_project_name": project_name})
+        view.fill({"delete_project_name": self.name})
         view.delete_btn.click()
         import time
 
@@ -187,8 +221,13 @@ class ProjectCollection(BaseCollection):
 
     ENTITY = Project
 
-    def create(self, name, description, app_list=None, transformation_path=None):
-        """Create a catalog.
+    def all(self):
+        """Return all projects instance of Project class"""
+        view = navigate_to(self, "All")
+        return [] if view.is_empty else [self.instantiate(name=p) for p in view.projects.items]
+
+    def create(self, name, description=None, app_list=None, transformation_path=None):
+        """Create a new project.
 
         Args:
             name: The name of the project
@@ -223,7 +262,8 @@ class All(RhamtNavigateStep):
     prerequisite = NavigateToAttribute("application.collections.base", "LoggedIn")
 
     def step(self, *args, **kwargs):
-        self.prerequisite_view.home_navigation.select("Projects")
+        if not self.prerequisite_view.is_empty:
+            self.prerequisite_view.home_navigation.select("Projects")
 
 
 @ViaWebUI.register_destination_for(ProjectCollection)
@@ -232,7 +272,10 @@ class Add(RhamtNavigateStep):
     prerequisite = NavigateToSibling("All")
 
     def step(self, *args, **kwargs):
-        self.prerequisite_view.new_project_button.click()
+        if self.prerequisite_view.is_empty:
+            self.prerequisite_view.blank_state.new_project_button.click()
+        else:
+            self.prerequisite_view.new_project_button.click()
 
 
 @ViaWebUI.register_destination_for(Project)
@@ -241,7 +284,8 @@ class Edit(RhamtNavigateStep):
     prerequisite = NavigateToAttribute("parent", "All")
 
     def step(self, *args, **kwargs):
-        self.prerequisite_view.project_list.edit_project(self.obj.name)
+        proj = self.prerequisite_view.projects.get_project(self.obj.name)
+        proj.edit()
 
 
 @ViaWebUI.register_destination_for(Project)
@@ -250,4 +294,5 @@ class Delete(RhamtNavigateStep):
     prerequisite = NavigateToAttribute("parent", "All")
 
     def step(self, *args, **kwargs):
-        self.prerequisite_view.project_list.delete_project(self.obj.name)
+        proj = self.prerequisite_view.projects.get_project(self.obj.name)
+        proj.delete()

--- a/rhamt/tests/test_multiple_projects_Test02.py
+++ b/rhamt/tests/test_multiple_projects_Test02.py
@@ -31,4 +31,4 @@ def test_multiple_applications_upload(request, application):
     wait_for(lambda: view.analysis_results.in_progress(), delay=0.2, timeout=120)
     wait_for(lambda: view.analysis_results.is_analysis_complete(), delay=0.2, timeout=120)
     assert view.analysis_results.is_analysis_complete()
-    project.delete(project_name)
+    project.delete()

--- a/rhamt/tests/test_projects_Test01.py
+++ b/rhamt/tests/test_projects_Test01.py
@@ -14,25 +14,33 @@ def test_project_crud(application):
     # TO DO paramterize the test later for file_name and trans_path, hardcoding for now
     project = project_collection.create(
         name=project_name,
-        description=fauxfactory.gen_alphanumeric(),
+        description=fauxfactory.gen_alphanumeric(start="desc_"),
         app_list=["acmeair-webapp-1.0-SNAPSHOT.war"],
         transformation_path="Containerization",
     )
-    assert project.exists(project_name)
+    assert project.exists
 
     # Edit Project with no change , clicks cancel
     project.update({"name": project_name})
     assert project.name == project_name
 
     # Edit Project with new desc and save
+    updated_name = fauxfactory.gen_alphanumeric(12, start="edited_")
     update_descr = "my edited description"
     with update(project):
+        project.name = updated_name
         project.description = update_descr
-    assert project.description == update_descr
+
+    assert project.exists
+    view = navigate_to(project.parent, "All")
+    # check name and description both updated on UI or not
+    proj = view.projects.get_project(project.name)
+    assert proj.name == updated_name
+    assert proj.description == update_descr
 
     # Delete project
-    project.delete(project_name)
-    assert not project.exists(project_name)
+    project.delete()
+    assert not project.exists
 
 
 def test_delete_application(application):


### PR DESCRIPTION
- Navigation was failing when no project available: Added `BlankStateView` and `is_empty` property
- `Add` and `All` navigation now checking `is_empty` and taking a respective decisions. 
- Added `all` method which returns instance of `Project` class