### PR TITLE
Setup env.local.yaml with command

### DIFF
--- a/rhamt/conf/credentials.yaml
+++ b/rhamt/conf/credentials.yaml
@@ -1,3 +1,0 @@
-ftpserver:
-  password: password
-  username: user

--- a/rhamt/conf/env.yaml
+++ b/rhamt/conf/env.yaml
@@ -6,7 +6,7 @@ browser:
   #webdriver_wharf: http://wharf_url
   webdriver: Remote
   webdriver_options:
-    #command_executor: http://localhost:4444/wd/hub
+    command_executor: http://localhost:4444/wd/hub
     desired_capabilities:
       acceptInsecureCerts: true
       acceptSslCerts: true
@@ -16,7 +16,9 @@ browser:
 
 ftpserver:
   host:
-  credentials: ftpserver
+  credentials:
+    password:
+    username:
   entrypoint: "/mnt/zpool01/files"
   entities:
     # Storage path on FTP Server.

--- a/rhamt/scripting/cli.py
+++ b/rhamt/scripting/cli.py
@@ -1,5 +1,6 @@
 import click
 
+from rhamt.scripting.config import main as config
 from rhamt.scripting.selenium_container import main as sel_container
 from rhamt.scripting.shell import main as shell
 
@@ -12,6 +13,7 @@ def cli():
 
 cli.add_command(shell, name="shell")
 cli.add_command(sel_container, name="selenium")
+cli.add_command(config, name="conf")
 
 if __name__ == "__main__":
     cli()

--- a/rhamt/scripting/config.py
+++ b/rhamt/scripting/config.py
@@ -1,0 +1,63 @@
+import click
+from yaml import safe_dump
+from yaml import safe_load
+
+from rhamt.utils.path import CONF_PATH
+
+ENV_LOCAL_CONF = CONF_PATH / "env.local.yaml"
+ENV_CONF = CONF_PATH / "env.yaml"
+
+
+@click.group()
+def main():
+    """RHAMT Configuration."""
+    pass
+
+
+@main.command(help="Create env.local.yaml file")
+@click.option(
+    "-h", "--hostname", default="http://localhost:8080", help="Hostname of the target application"
+)
+@click.option(
+    "-d",
+    "--webdriver",
+    default="Remote",
+    type=click.Choice(["Remote", "Chrome", "Firefox"]),
+    help="Webdriver",
+)
+@click.option(
+    "-w", "--wharf", default=None, help="Address of the wharf server for remote webdrivers"
+)
+@click.option(
+    "-e", "--executor", default="http://localhost:4444/wd/hub", help="Selenium Command executor"
+)
+@click.option(
+    "-b",
+    "--browser",
+    default="chrome",
+    type=click.Choice(["chrome", "firefox"]),
+    help="Browser name.",
+)
+@click.option("-fh", "--ftp-host", default=None, help="FTP server hostname")
+@click.option("-fu", "--ftp-username", default=None, help="FTP server username")
+@click.option("-fp", "--ftp-password", default=None, help="FTP server password")
+@click.option("-o", "--output-file", default=ENV_LOCAL_CONF, help="Output file for yaml dump")
+def local_env(
+    hostname, webdriver, wharf, executor, browser, ftp_host, ftp_username, ftp_password, output_file
+):
+    with open(ENV_CONF, "r") as env_conf:
+        conf = safe_load(env_conf)
+
+    conf["application"]["hostname"] = hostname
+    conf["browser"]["webdriver"] = webdriver
+    conf["browser"]["webdriver_options"]["command_executor"] = executor
+    conf["browser"]["webdriver_options"]["desired_capabilities"]["browserName"] = browser
+    conf["ftpserver"]["host"] = ftp_host
+    conf["ftpserver"]["credentials"]["username"] = ftp_username
+    conf["ftpserver"]["credentials"]["password"] = ftp_password
+
+    if wharf:
+        conf["browser"]["webdriver_wharf"] = wharf
+
+    with open(output_file, "w") as env_conf:
+        return safe_dump(conf, env_conf, default_flow_style=False)

--- a/rhamt/utils/ftp.py
+++ b/rhamt/utils/ftp.py
@@ -578,14 +578,12 @@ class FTPClientWrapper(FTPClient):
     """
 
     def __init__(self, entity_path=None, entrypoint=None, host=None, login=None, password=None):
-        credentials = conf.get_config("credentials")
         env = conf.get_config("env")
-        ftp_data = env.ftpserver
-        host = host or ftp_data.host
-        login = login or credentials[ftp_data.credentials]["username"]
-        password = password or credentials[ftp_data.credentials]["password"]
+        host = host or env.ftpserver.host
+        login = login or env.ftpserver.credentials.username
+        password = password or env.ftpserver.credentials.password
 
-        self.entrypoint = entrypoint or ftp_data.entrypoint
+        self.entrypoint = entrypoint or env.ftpserver.entrypoint
         self.entity_path = entity_path
 
         super(FTPClientWrapper, self).__init__(


### PR DESCRIPTION
- Create `env.local.yaml` with rham command line
- It will help to create local env while running Jenkin jobs just by passing arguments.

```
❯ rhamt conf local-env --help
Usage: rhamt conf local-env [OPTIONS]

  Create env.local.yaml file

Options:
  -h, --hostname TEXT             Hostname of the target application
  -d, --webdriver [Remote|Chrome|Firefox]
                                  Webdriver
  -w, --wharf TEXT                Address of the wharf server for remote
                                  webdrivers

  -e, --executor TEXT             Selenium Command executor
  -b, --browser [chrome|firefox]  Browser name.
  -fh, --ftp-host TEXT            FTP server hostname
  -fu, --ftp-username TEXT        FTP server username
  -fu, --ftp-password TEXT        FTP server password
  -o, --output-file TEXT          Output file for yaml dump
  --help                          Show this message and exit.

```