### PR TITLE
OpenShift CI - Interop MTR Scenario Updates

### DIFF
--- a/dockerfiles/interop/Dockerfile
+++ b/dockerfiles/interop/Dockerfile
@@ -1,0 +1,34 @@
+FROM python:3.8
+
+# Update and install FTP
+RUN apt -y update && apt -y install ftp
+
+# Upgrade pip and install required packages
+RUN pip install --upgrade pip
+RUN pip install pytest importscan pyftpdlib
+
+# Copy the windup_integration_test repo into /tmp/integration_tests
+RUN mkdir /tmp/integration_tests
+WORKDIR /tmp/integration_tests
+COPY . .
+
+# Add interop env file to mta/conf/env.yaml
+COPY dockerfiles/interop/src/env.yaml mta/conf/env.yaml
+
+# Create the /ftpuser directory
+RUN mkdir -p /home/ftpuser/mtr/applications
+
+# Add WAR file for testing
+COPY dockerfiles/interop/src/acmeair-webapp-1.0-SNAPSHOT.war /home/ftpuser/mtr/applications/acmeair-webapp-1.0-SNAPSHOT.war
+
+# Add ftp_server.py script
+COPY dockerfiles/interop/src/ftp_server.py /tmp/ftp_server.py
+
+# Set required permissions for OpenShift usage
+RUN chgrp -R 0 /tmp && \
+    chmod -R g=u /tmp
+
+RUN chgrp -R 0 /home && \
+    chmod -R g=u /home
+
+CMD ["/bin/bash"]

--- a/dockerfiles/interop/src/env.yaml
+++ b/dockerfiles/interop/src/env.yaml
@@ -1,0 +1,25 @@
+application:
+  hostname: REPLACE_HOSTNAME
+  ocphostname: REPLACE_OCP_HOSTNAME
+  ocpsecurehostname: REPLACE_OCP_SECURE_HOSTNAME
+  password: REPLACE_MTR_PASSWORD
+  user: REPLACE_MTR_USER
+  version: REPLACE_MTR_VERSION
+browser:
+  webdriver: Remote
+  webdriver_options:
+    command_executor: REPLACE_EXECUTOR
+    desired_capabilities:
+      acceptInsecureCerts: true
+      acceptSslCerts: true
+      browserName: chrome
+      unexpectedAlertBehaviour: ignore
+ftpserver:
+  credentials:
+    password: REPLACE_FTP_PASSWORD
+    username: REPLACE_FTP_USERNAME
+  entities:
+    mta: mtr/applications
+  entrypoint: ""
+  host: REPLACE_FTP_HOST
+  port: 3333

--- a/dockerfiles/interop/src/ftp_server.py
+++ b/dockerfiles/interop/src/ftp_server.py
@@ -1,0 +1,40 @@
+import logging
+
+from pyftpdlib.authorizers import DummyAuthorizer
+from pyftpdlib.handlers import FTPHandler
+from pyftpdlib.servers import FTPServer
+
+
+def main():
+    # Instantiate a dummy authorizer for managing 'virtual' users
+    authorizer = DummyAuthorizer()
+
+    # Define a new user having full r/w permissions and a read-only
+    authorizer.add_user("ftpuser", "ftpuser", "/home/ftpuser/", perm="elradfmwMT")
+
+    # Instantiate FTP handler class
+    handler = FTPHandler
+    handler.authorizer = authorizer
+    # Passive ports
+    handler.passive_ports = range(5000, 5020)
+    handler.permit_foreign_addresses = True
+
+    handler.banner = "MTR Interop Test FTP Server"
+
+    # connect using an address 0.0.0.0 with port 21
+    address = ("127.0.0.1", 3333)
+    server = FTPServer(address, handler)
+
+    # set a limit for connections
+    server.max_cons = 5
+    server.max_cons_per_ip = 5
+
+    # Add logging
+    logging.basicConfig(filename="/tmp/ftp_log.txt", level=logging.DEBUG)
+
+    # start ftp server
+    server.serve_forever()
+
+
+if __name__ == "__main__":
+    main()

--- a/mta/conf/env.yaml
+++ b/mta/conf/env.yaml
@@ -20,6 +20,7 @@ browser:
 
 ftpserver:
   host: rhev-node-09.rdu2.scalelab.redhat.com
+  port: 21
   credentials:
     password:
     username:

--- a/mta/utils/ftp.py
+++ b/mta/utils/ftp.py
@@ -270,7 +270,7 @@ class FTPClient(object):
 
     """
 
-    def __init__(self, host, login, password, upload_dir="/", time_diff=True):
+    def __init__(self, host, login, password, port, upload_dir="/", time_diff=True):
         """Constructor
 
         Args:
@@ -280,6 +280,7 @@ class FTPClient(object):
             time_diff: Server and client time diff management
         """
         self.host = host
+        self.port = port
         self.login = login
         self.password = password
         self.ftp = None
@@ -290,7 +291,8 @@ class FTPClient(object):
             self.update_time_difference()
 
     def connect(self):
-        self.ftp = ftplib.FTP(self.host)
+        self.ftp = ftplib.FTP()
+        self.ftp.connect(self.host, self.port)
         self.ftp.login(self.login, self.password)
         logger.info("FTP Server login successful")
 
@@ -571,9 +573,12 @@ class FTPClientWrapper(FTPClient):
           f.download()  # download file
     """
 
-    def __init__(self, entity_path=None, entrypoint=None, host=None, login=None, password=None):
+    def __init__(
+        self, entity_path=None, entrypoint=None, host=None, login=None, password=None, port=None
+    ):
         env = conf.get_config("env")
         host = host or env.ftpserver.host
+        port = port or env.ftpserver.port
         login = login or env.ftpserver.credentials.username
         password = password or env.ftpserver.credentials.password
 
@@ -581,7 +586,7 @@ class FTPClientWrapper(FTPClient):
         self.entity_path = entity_path
 
         super(FTPClientWrapper, self).__init__(
-            host=host, login=login, password=password, time_diff=False
+            host=host, login=login, password=password, port=port, time_diff=False
         )
 
         # Change working directory as per entity_path if provided


### PR DESCRIPTION
**Changes Made:**

1. **ADD** `dockerfiles/interop/Dockerfile` - This is the Dockerfile that OpenShift CI uses to execute the actual tests in this repository
2. **ADD** `dockerfiles/interop/src/acmeair-webapp-1.0-SNAPSHOT.war` - This is the file used to test with. This file is served on the local FTP server that runs in the container created by the new Dockerfile
3. **ADD** `dockerfiles/interop/src/env.yaml` - A different version of `mta/conf/env.yaml`. This was created to replace the values needed more easily in the OpenShift CI script
4. **ADD** `dockerfiles/interop/src/ftp_server.py` - This script is used by the container created by the new Dockerfile to start the local FTP server for test execution. The server must start on a port other than 21 due to permission errors within OpenShift. Hence, why I have included a `port` value in the `env.yaml` file.
5. **CHANGE** `mta/conf/env.yaml` - Include a `port` key/value pair to support ports other than 21.
6. **CHANGE** `mta/utils/ftp.py` - Add logic to support using ports other than 21 for FTP.

These changes are to support the port over of the MTR scenario to OpenShift CI. Please see [this epic](https://issues.redhat.com/browse/CSPIT-204) for more information, or feel free to reach out to me via Slack or Email.